### PR TITLE
Clean up code and typing for the type checker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,7 +104,7 @@ ipython_config.py
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
 #   commonly ignored for libraries.
 #   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
-#poetry.lock
+poetry.lock
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow
 __pypackages__/

--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# ignore this
+cmds.txt

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 # pygeolocate/examples/get_country_by_full_name.py
 import pygeolocate
 
-united_kingdom = pygeolocate.locate_by_name("united kingdom")
+united_kingdom = pygeolocate.locate_by_name("united kingdom")[0]
 
 print(country)
 print(country.name)

--- a/pygeolocate/__init__.py
+++ b/pygeolocate/__init__.py
@@ -23,6 +23,11 @@ from .pygeolocate import (
     locate_by_code,
 )
 
+__all__ = (
+    "locate_by_name",
+    "locate_by_code",
+)
+
 __author__ = "Scrumpyy"
 
 __version__ = "1.0.8"

--- a/pygeolocate/__init__.py
+++ b/pygeolocate/__init__.py
@@ -30,4 +30,4 @@ __all__ = (
 
 __author__ = "Scrumpyy"
 
-__version__ = "1.0.8"
+__version__ = "1.0.10"

--- a/pygeolocate/examples/get_country_by_full_name.py
+++ b/pygeolocate/examples/get_country_by_full_name.py
@@ -1,6 +1,6 @@
 import pylocate
 
-united_kingdom = pylocate.locate_by_name("united kingdom")
+united_kingdom = pylocate.locate_by_name("united kingdom")[0]
 
 print(country)
 print(country.name)

--- a/pygeolocate/pygeolocate.py
+++ b/pygeolocate/pygeolocate.py
@@ -19,8 +19,8 @@ SOFTWARE.
 """
 
 from typing import (
-    Union,
-    Tuple,
+    Any,
+    Optional,
     List,
     Dict,
 )
@@ -32,7 +32,7 @@ from .structures import (
 
 from .countries_csv import DATA as countries_csv_data
 
-def _get_raw_country_data() -> List[Dict]:
+def _get_raw_country_data() -> List[Dict[str, Any]]:
     return [
         {
             'code':  country_data.split(",")[0],
@@ -40,7 +40,7 @@ def _get_raw_country_data() -> List[Dict]:
             'coordinates': {
                 'latitude': country_data.split(",")[1],
                 'longitude': country_data.split(",")[2],
-            }
+            },
         } for country_data in countries_csv_data.split("\n")
     ]
 
@@ -56,16 +56,16 @@ def locate_by_name(country_name: str) -> List[Country]:
 
     return [
         Country(
-            country['code'], 
-            country['name'], 
+            country['code'],
+            country['name'],
             Coordinates(
-                country['coordinates']['latitude'], 
-                country['coordinates']['longitude']
-            )
+                country['coordinates']['latitude'],
+                country['coordinates']['longitude'],
+            ),
         ) for country in countries if country_name.lower().replace(" ", "") in country['name'].lower().replace(" ", "") 
     ]
 
-def locate_by_code(country_code: str) -> Union[None, Country]:
+def locate_by_code(country_code: str) -> Optional[Country]:
     """
         Returns `None` if `country_code` is invalid, else it returns a `Country` object.
     """
@@ -75,12 +75,12 @@ def locate_by_code(country_code: str) -> Union[None, Country]:
     for country in countries:
         if country['code'].lower() == country_code.lower():
             return Country(
-                country['code'], 
-                country['name'], 
+                country['code'],
+                country['name'],
                 Coordinates(
-                    country['coordinates']['latitude'], 
-                    country['coordinates']['longitude']
-                )
+                    country['coordinates']['latitude'],
+                    country['coordinates']['longitude'],
+                ),
             )
 
     return None

--- a/pygeolocate/structures.py
+++ b/pygeolocate/structures.py
@@ -19,39 +19,48 @@ SOFTWARE.
 """
 
 from typing import (
-    List,
     Tuple,
     Union,
+    overload,
 )
 
 class Coordinates:
     def __init__(self, latitude: float, longitude: float) -> None:
         self._latitude = latitude
         self._longitude = longitude
-    
+
     @property
     def latitude(self) -> float:
         return self._latitude
-    
+
     @property
     def longitude(self) -> float:
         return self._longitude
 
+    @overload
+    def __getitem__(self, item: int) -> float: ...
+
+    @overload
+    def __getitem__(self, item: str) -> float: ...
+
     def __getitem__(self, item: Union[int, str]) -> float:
-        if type(item) == int:
+        if not isinstance(item, (int, str)):  # type: ignore
+            raise TypeError("Index must be either an int or a str.")
+
+        if isinstance(item, int):
             if item == 0:
                 return self._latitude
             elif item == 1:
                 return self._longitude
             else:
                 raise IndexError("Index out of range, needs to be either 0 or 1.")
-        elif type(item) == str:
-            if item.lower() in ["lat", "latitude"]:
-                return self._latitude
-            elif item.lower() in ["long", "longitude"]:
-                return self._longitude
-            else:
-                raise ValueError("Item not found.")
+
+        if item.lower() in ["lat", "latitude"]:
+            return self._latitude
+        elif item.lower() in ["long", "longitude"]:
+            return self._longitude
+        else:
+            raise ValueError("Item not found.")
 
     def __tuple__(self) -> Tuple[float, float]:
         return (self._latitude, self._longitude)
@@ -64,11 +73,11 @@ class Country:
         self._country_code = country_code
         self._country_name = country_name
         self._coordinates = coordinates
-    
+
     @property
     def coordinates(self) -> Coordinates:
         return self._coordinates
-    
+
     @property
     def name(self) -> str:
         return self._country_name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pygeolocate"
-version = "1.0.8"
+version = "1.0.10"
 description = "An easy way to find a countries coordinates by name"
 authors = ["Scrumpyy <scrumpy@weeb.email>"]
 license = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-VERSION = '1.0.8'
+VERSION = '1.0.10'
 DESCRIPTION = 'An easy way to find a countries coordinates by name'
 
 try:


### PR DESCRIPTION
This PR cleans up and corrects elements of the lib's typing to make the type checker happy. I've ignored setup.py and the examples directory since they're not relevant to the library being imported, but the in-lib types now pass type checking.

This also uncomments poetry.lock in the gitignore file since this is typically ignored for libraries. In addition, some excess spaces and missing trailing commas have been removed and added respectively.